### PR TITLE
fixed wrong name of chain in crosschain button

### DIFF
--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -675,7 +675,7 @@ export default function Swap() {
               {isCrossChain && transferAmount.length && transferAmount !== '0' ? (
                 <>
                   <ButtonPrimary onClick={showConfirmTransferModal}>
-                    Transfer {currencies[Field.INPUT]?.symbol} Tokens to {transferTo}
+                    Transfer {currencies[Field.INPUT]?.symbol} Tokens to {targetChain.name}
                   </ButtonPrimary>
                 </>
               ) : !account ? (


### PR DESCRIPTION
the issue from https://trello.com/c/LANsI69h/112-wrong-name-of-chain-in-crosschain-button